### PR TITLE
neovim-nightly: update to 0.8.0-dev+296-g307c5c63e

### DIFF
--- a/packages/neovim-nightly/build.sh
+++ b/packages/neovim-nightly/build.sh
@@ -2,9 +2,9 @@ TERMUX_PKG_HOMEPAGE=https://neovim.io
 TERMUX_PKG_DESCRIPTION="Ambitious Vim-fork focused on extensibility and agility (nvim-nightly)"
 TERMUX_PKG_LICENSE="Apache-2.0"
 TERMUX_PKG_MAINTAINER="Aditya Alok <alok@termux.org>"
-TERMUX_PKG_VERSION="0.8.0-dev+289-g9e1ee9fb1"
+TERMUX_PKG_VERSION="0.8.0-dev+296-g307c5c63e"
 TERMUX_PKG_SRCURL="https://github.com/neovim/neovim/archive/nightly.tar.gz"
-TERMUX_PKG_SHA256=0eca1864a610a6b4183e70f5438a48812bd3866fd5ed296b541f11391388a75f
+TERMUX_PKG_SHA256=2e3b33f9d86a465e67a7823a5bc41422f6322308ff687cafd3e2c44125ae8c87
 TERMUX_PKG_DEPENDS="libiconv, libuv, luv, libmsgpack, libandroid-support, libvterm, libtermkey, libluajit, libunibilium, libtreesitter"
 TERMUX_PKG_HOSTBUILD=true
 


### PR DESCRIPTION
This commit has been automatically submitted by Github Actions.